### PR TITLE
fix endpoint, types, and import

### DIFF
--- a/tutorials/HRTool/handlers/app/event.py
+++ b/tutorials/HRTool/handlers/app/event.py
@@ -2,15 +2,15 @@ from gql import gql, Client
 from gql.transport.requests import RequestsHTTPTransport
 
 # GraphQL endpoint URL
-GRAPHQL_ENDPOINT = "http://localhost:8080/v1/graphql"
+GRAPHQL_ENDPOINT = "http://graphql-engine:8080/v1/graphql"
 
 
 def handle_insert(row, client):
-    id = row['id']
+    id = str(row['id'])
     # In reality you would follow the URL from row['url']
     content = "dummy content"
     gql_query = gql("""
-            mutation insertItem($id: String!, $content: text!) {
+            mutation insertItem($id: text!, $content: text!) {
                 insert_Resume_one(object: { application_id: $id, content: $content }) {
                     id
                 }
@@ -23,7 +23,7 @@ def handle_insert(row, client):
 def handle_delete(row, client):
     id = row['id']
     gql_query = gql("""
-            mutation deleteItem($id: String!) {
+            mutation deleteItem($id: text!) {
                 delete_Resume(where: {application_id: { _eq: $id } }) {
                     affected_rows
                 }

--- a/tutorials/HRTool/handlers/app/query_llm.py
+++ b/tutorials/HRTool/handlers/app/query_llm.py
@@ -8,7 +8,7 @@ from langchain.prompts import PromptTemplate
 from langchain.chat_models import ChatOpenAI
 
 # GraphQL endpoint URL
-GRAPHQL_ENDPOINT = "http://localhost:8080/v1/graphql"
+GRAPHQL_ENDPOINT = "http://graphql-engine:8080/v1/graphql"
 
 
 def get_prompt(request):

--- a/tutorials/HRTool/handlers/pyproject.toml
+++ b/tutorials/HRTool/handlers/pyproject.toml
@@ -10,6 +10,7 @@ python = "^3.11"
 Flask = "2.3.2"
 requests = "2.31.0"
 langchain = "0.0.229"
+openai = "0.27.8"
 requests-toolbelt = "^1.0.0"
 gql = "^3.4.1"
 


### PR DESCRIPTION
I was unable to get the repository to work as it is on `main`. 

When running `docker logs -f <handlers_container_id>`, and attempting to use `near_text` queries via an Event Trigger, there was continually an error that the service on port `8080` wasn't available and the connection was refused. Using the name of the service was the only way I could get it to work.

This same pattern was true for the `query_llm` module, except there was also an existing type issue that I thought was resolved.

Finally, `openai` wasn't included in the `TOML` file used by the `handlers` service.

If you folks agree with these changes, the [Learn tutorial](https://github.com/hasura/learn-graphql/pull/967) is good to go 🤙 

It'd be really great if someone could do an end-to-end by seeing if they can get both `near_text` and LLM queries to work.